### PR TITLE
DTO 들에 Serializable 인터페이스 제거

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/response/ArticleCommentResponse.java
+++ b/src/main/java/com/fastcampus/projectboard/response/ArticleCommentResponse.java
@@ -10,7 +10,7 @@ public record ArticleCommentResponse(
         String content,
         LocalDateTime createdAt,
         String email,
-        String nickname) implements Serializable {
+        String nickname) {
 
     public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleCommentResponse(id, content, createdAt, email, nickname);

--- a/src/main/java/com/fastcampus/projectboard/response/ArticleResponse.java
+++ b/src/main/java/com/fastcampus/projectboard/response/ArticleResponse.java
@@ -23,7 +23,7 @@ public record ArticleResponse(
         String hashtag,
         LocalDateTime createdAt,
         String email,
-        String nickname) implements Serializable {
+        String nickname) {
 
     public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);

--- a/src/main/java/com/fastcampus/projectboard/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/fastcampus/projectboard/response/ArticleWithCommentsResponse.java
@@ -16,7 +16,7 @@ public record ArticleWithCommentsResponse(
         LocalDateTime createdAt,
         String email,
         String nickname,
-        Set<ArticleCommentResponse> articleCommentsResponses) implements Serializable {
+        Set<ArticleCommentResponse> articleCommentsResponses) {
 
     public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
         return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);


### PR DESCRIPTION
JPA Buddy 를 이용해 작성한 DTO들인데,
자동으로 `implements Serialization` 이 들어가버림
우리 프로젝트는 직렬화로 Jackson 을 사용하므로
필요하지 않고, 의도하여 넣은 코드도 아님
그러므로 삭제