### PR TITLE
엔티티 equals() 버그 수정

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/domain/Article.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/Article.java
@@ -65,10 +65,10 @@ public class Article extends AuditingFields{
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Article article)) return false;
+        if (!(o instanceof Article that)) return false;
 //        if (o == null || getClass() != o.getClass()) return false;
 //        Article article = (Article) o;
-        return id != null && id.equals(article.id);
+        return id != null && id.equals(that.getId());
     }
 
     /*

--- a/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
@@ -42,10 +42,10 @@ public class ArticleComment extends AuditingFields{
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof ArticleComment articleComment)) return false;
+        if (!(o instanceof ArticleComment that)) return false;
 //        if (o == null || getClass() != o.getClass()) return false;
 //        ArticleComment that = (ArticleComment) o;
-        return id != null && id.equals(articleComment.id);
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
@@ -44,10 +44,10 @@ public class UserAccount extends AuditingFields{
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount userAccount)) return false;
+        if (!(o instanceof UserAccount that)) return false;
 //        if (o == null || getClass() != o.getClass()) return false;
 //        UserAccount that = (UserAccount) o;
-        return userId != null && userId.equals(userAccount.userId);
+        return userId != null && userId.equals(that.getUserId());
     }
 
     @Override


### PR DESCRIPTION
테스트 도중 밝혀진 엔티티 `equals()` 구현 코드의 문제를 해결하는 pr

This closes #50 